### PR TITLE
Return raw covariance samples

### DIFF
--- a/R/bayes_reliability.R
+++ b/R/bayes_reliability.R
@@ -10,7 +10,8 @@
 brel <- function(raw.data, boot.n = 200, interval = .95, boot.interval.type = "basic",
                 jags = FALSE, n.iter = 2e3, n.burnin = 50, freq = TRUE,
                 estimates = c("alpha", "l2", "l6", "glb", "omega"), supr.warnings = TRUE,
-                omega.freq.method = "pa", omega.conf.type = "boot", omega.cov.samp = TRUE) {
+                omega.freq.method = "pa", omega.conf.type = "boot", omega.cov.samp = TRUE,
+				returnSamples = FALSE) {
   if (supr.warnings) {
     options(warn = - 1)
   }
@@ -31,7 +32,7 @@ brel <- function(raw.data, boot.n = 200, interval = .95, boot.interval.type = "b
     sum.res$omega.pa <- omega.cov.samp
   }
   else{
-    sum.res$bay <- gibbsFun(data, n.iter, n.burnin, estimates, interval, omega.cov.samp)
+    sum.res$bay <- gibbsFun(data, n.iter, n.burnin, estimates, interval, omega.cov.samp, returnSamples)
     sum.res$bayes.method <- "gibbs"
     sum.res$omega.pa <- omega.cov.samp
   }

--- a/R/gibbs_output.R
+++ b/R/gibbs_output.R
@@ -2,11 +2,17 @@
 #' and the credible intervals together with the posterior distribution objects
 #' to be passed on for forther analysis
 
-gibbsFun <- function(data, n.iter, n.burnin, estimates, interval, omega.cov.samp){
+gibbsFun <- function(data, n.iter, n.burnin, estimates, interval, omega.cov.samp, returnSamples = FALSE){
   if ("alpha" %in% estimates || "l2" %in% estimates || "l6" %in% estimates || "glb" %in% estimates || omega.cov.samp){
     C <- covSamp2(data, n.iter, n.burnin)
+  } else {
+  	C <- NULL
   }
-  res <- list()
+  if (returnSamples) {
+  	res <- list(samp = list(C = C))
+  } else {
+  	res <- list()
+  }
 
   if ("alpha" %in% estimates){
     res$samp$gibbs.alpha <- coda::as.mcmc(apply(C, MARGIN = 1, applyAlpha))

--- a/R/ifItemDroppedExample.R
+++ b/R/ifItemDroppedExample.R
@@ -1,0 +1,43 @@
+p <- 40
+nobs <- 10
+
+# some covariance matrix
+aa <- matrix(runif(p^2), p, p)
+sigma <- t(aa) %*% aa
+
+x <- mvtnorm::rmvnorm(n=500, sigma=sigma)
+
+# covariance are equal
+cov0 <- var(x)[1:(p-1), 1:(p-1)]
+cov1 <- var(x[, 1:(p-1)])
+all.equal(cov0, cov1)
+
+# I made a small adjustment to store
+# C in res$samp$C in gibbsFun. Perhaps it is nice
+#  to allow this with a boolean that is FALSE by default
+# (e.g., storeCovSamples = FALSE).
+
+n.iter <- 1e4
+
+# the full thing
+e0 <- bayesrel::brel(x, freq = FALSE, estimates = "alpha", n.iter = n.iter, returnSamples = TRUE)
+# extract the covariance samples but drop one variable
+C0 <- e0$bay$samp$C[, 1:(p-1), 1:(p-1)] # estimates
+# calculate alpha on reduced covariance samples
+e0a <- coda::as.mcmc(apply(C0, MARGIN = 1, bayesrel:::applyAlpha))
+# directly calculate alpha on reduced dataset
+e1 <- bayesrel::brel(x[, 1:(p-1)], freq = FALSE, estimates = "alpha", n.iter = n.iter, returnSamples = TRUE)
+e1a <- e1$bay$samp$gibbs.alpha
+
+# density plot
+par(bty = "n", las = 1)
+# plot(density(e0a))
+# lines(density(e1a), col = 2)
+
+# very convincing qq-plot
+step <- 1e-3
+probs <- seq(step, 1 - step, step)
+q0 <- quantile(e0a, probs = probs)
+q1 <- quantile(e1a, probs = probs)
+plot(q0, q1)
+abline(0, 1)

--- a/R/princ_fac.R
+++ b/R/princ_fac.R
@@ -10,7 +10,7 @@ princFac <- function(m, max.iter = 50){
   h2 <- sum(diag(r))
   error <- h2
   i <- 1
-  while (error > min.error){
+  while (error > min.error || i == 1){
     r.eigen <- eigen(r)
 
     lambda <- as.matrix(r.eigen$vectors[, 1] * sqrt(r.eigen$values[1]))


### PR DESCRIPTION
- `R/bayes_reliability.R`
Added argument to return samples (when using gibbs sampling).

- `R/gibbs_output.R`
Added argument to return samples.

- `R/ifItemDroppedExample.R`
Updated example (now uses `returnSamples` argument).

 - `R/princ_fac.R`
No longer crashes when `error > min.error` is `FALSE` and the while loop is never entered.

